### PR TITLE
Change of #include to match case of filename.

### DIFF
--- a/LoRaCode.cpp
+++ b/LoRaCode.cpp
@@ -35,7 +35,7 @@
 #include <Arduino.h>
 #include <Battery.h>
 #elif defined(ARDUINO_ARCH_ESP8266) | defined(ESP32)
-#include <ESP.h>
+#include <Esp.h>			// change case of #include to match filename
 #elif defined(__MKL26Z64__)
 #include <Arduino.h>
 #else


### PR DESCRIPTION
Correctly matching case of filename will prevent compile errors in linux. (ESP.h ==> Esp.h)